### PR TITLE
removed extra php opening tag:line-28

### DIFF
--- a/docs/dg/dev/glue-api/202311.0/create-json-api-relationships.md
+++ b/docs/dg/dev/glue-api/202311.0/create-json-api-relationships.md
@@ -27,8 +27,6 @@ Let's say you have a module named `ModuleRestApi`, where you want to add the `ba
 ```php
 <?php
 
-<?php
-
 namespace Pyz\Glue\ModuleRestApi\Plugin\GlueJsonApiConvention;
 
 use Generated\Shared\Transfer\GlueRelationshipTransfer;


### PR DESCRIPTION
Removed an extra php opening tag from the code snip for src\Pyz\Glue\ModuleRestApi\Plugin\ModuleBarResourceRelationshipPlugin.php of the doc Create JSON:API relationships.